### PR TITLE
Avoid unnecessary registration of taxonomy metaboxes

### DIFF
--- a/includes/meta-box.php
+++ b/includes/meta-box.php
@@ -224,16 +224,3 @@ function postscript_save_post_meta( $post_id, $post ) {
 
 }
 
-/**
- * Removes default display of plugin's custom tax checkboxes.
- * (Handled by plugin's meta box. Save won't work if both tax forms are in form.)
- */
-function postscript_remove_meta_boxes() {
-    $options = postscript_get_options( 'postscript' );
-
-    foreach ( $options['post_types'] as $post_type ) {
-        remove_meta_box( 'postscript_scriptsdiv', $post_type, 'normal' );
-        remove_meta_box( 'postscript_stylesdiv', $post_type, 'normal' );
-    }
-}
-add_action( 'admin_menu' , 'postscript_remove_meta_boxes' );

--- a/postscript.php
+++ b/postscript.php
@@ -133,6 +133,7 @@ function postscript_create_taxonomies() {
         'labels'            => $labels_scripts,
         'public'            => true,
         'query_var'         => true,
+        'meta_box_cb'       => false,
         'capabilities' => array(
             'manage_terms' => 'manage_options',
             'edit_terms'   => 'manage_options',
@@ -168,6 +169,7 @@ function postscript_create_taxonomies() {
         'labels'            => $labels_styles,
         'public'            => true,
         'query_var'         => true,
+        'meta_box_cb'       => false,
         'capabilities' => array(
             'manage_terms' => 'manage_options',
             'edit_terms'   => 'manage_options',


### PR DESCRIPTION
`meta_box_cb=>false` is equivalent to not registering the metabox in the
first place
